### PR TITLE
Added missing visitlong()

### DIFF
--- a/meta/asttools/visitors/pysourcegen.py
+++ b/meta/asttools/visitors/pysourcegen.py
@@ -176,6 +176,9 @@ class ExprSourceGen(Visitor):
 
     def visitNum(self, node):
         self.print(repr(node.n))
+        
+    def visitlong(self, node):
+        self.print(repr(node))
 
     def visitBinOp(self, node):
         self.print('({left:node} {op:node} {right:node})', left=node.left, op=node.op, right=node.right)


### PR DESCRIPTION
Using meta 0.4.1, the following code throws an exception about missing `visitlong()`:

``` python
import meta

def f(x):
    return x & 0xffff0000

f_ast = meta.decompiler.decompile_func(f)
meta.asttools.print_ast(f_ast)
print meta.dump_python_source(f_ast)
```

The exception is:

``` python
AttributeError: 'ExprSourceGen' object has no attribute 'visitlong'
```

The proposed patch fixes this.
I am not sure why `decompile_func()` would generate a `long` type as a node in the first place. This might hide another issue.
