### PR TITLE
Make version in source match version on pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except IOError as err:
     long_description = str(err)
 
 try:
-    version_str = open('version.txt').read()
+    version_str = open('version.txt').read().strip()
 except IOError as err:
     version_str = '???'
 

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-development
+0.4.1


### PR DESCRIPTION
The reason for this is that is it expected that versions on pypi and in source match - if they don't, than for example installing from local wheel folder does not work.
