### PR TITLE
Fixes for Python 3.3 and 3.4

### DIFF
--- a/meta/asttools/visitors/pysourcegen.py
+++ b/meta/asttools/visitors/pysourcegen.py
@@ -709,6 +709,32 @@ class SourceGen(ExprSourceGen):
         if node.value is not None:
             self.print('return {:node}\n', node.value)
 
+    def visitTry(self, node):
+        # From Python 3.3, TryExcept and TryFinally are unified as Try
+        self.print('try:')
+
+        with self.indenter:
+            if node.body:
+                for stmnt in node.body:
+                    self.visit(stmnt)
+            else:
+                self.print('pass')
+
+        for hndlr in node.handlers:
+            self.visit(hndlr)
+
+        if node.orelse:
+            self.print('else:')
+            with self.indenter:
+                for stmnt in node.orelse:
+                    self.visit(smnt)
+
+        if node.finalbody:
+            self.print('finally:')
+            with self.indenter:
+                for stmnt in node.finalbody:
+                    self.visit(stmnt)
+
     def visitTryExcept(self, node):
         self.print('try:')
 

--- a/meta/decompiler/control_flow_instructions.py
+++ b/meta/decompiler/control_flow_instructions.py
@@ -376,7 +376,8 @@ class CtrlFlowInstructions(object):
         else:
             else_ = []
 
-        try_except = _ast.TryExcept(body=body, handlers=handlers, orelse=else_, lineno=instr.lineno, col_offset=0)
+        try_except = _ast.Try(body=body, handlers=handlers, orelse=else_,
+                              finalbody=[], lineno=instr.lineno, col_offset=0)
 
         self.push_ast_item(try_except)
     

--- a/meta/decompiler/instructions.py
+++ b/meta/decompiler/instructions.py
@@ -351,6 +351,7 @@ class Instructions(CtrlFlowInstructions, SimpleInstructions):
     @py3op
     def MAKE_FUNCTION(self, instr):
 
+        name = self.pop_ast_item()
         code = self.pop_ast_item()
         
         ndefaults = bitrange(instr.oparg, 0, 8)

--- a/meta/decompiler/recompile.py
+++ b/meta/decompiler/recompile.py
@@ -17,7 +17,6 @@ else:
      
 import marshal
 import imp
-from py_compile import PyCompileError, wr_long
 
 MAGIC = imp.get_magic()
 


### PR DESCRIPTION
With these fixes, depyc works on itself on Python 3.4.
- `MAKE_FUNCTION` now expects a name on the top of the stack, then the code object. The name appears to be redundant with the name embedded in the code object, so for now I discard it.
- The `TryExcept` and `TryFinally` AST nodes were unified into a single `Try` node. Added support for this.

I'm assuming that there's no need to support Python 3 versions earlier than 3.3; if there is, extra branches will be needed for that.

All the affected code is in py3op functions, so operation on Python 2 should be unaffected.
