### PR TITLE
Add version.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include README.rst license.rst
+include README.rst license.rst version.txt
 recursive-include doc *
 


### PR DESCRIPTION
Add license.txt

I tested python setup.py sdist before and after the change.    After the change version.txt is included in the tar.gz


I haven't had time to test installing from pypi, but hopefully this finally fixes #23 