### PR TITLE
Correctly handle unpacked assignment for non-constant inside of function

### DIFF
--- a/meta/decompiler/simple_instructions.py
+++ b/meta/decompiler/simple_instructions.py
@@ -243,7 +243,7 @@ class SimpleInstructions(object):
             else:
                 if not isinstance(value.targets, _ast.Tuple):
                     value.targets = [_ast.Tuple(value.targets, _ast.Store())]
-                    value.value = _ast.Tuple([value.value], _ast.Store())
+                    value.value = _ast.Tuple([value.value], _ast.Load())
                     value.targets[0].lineno = value.targets[0].elts[0].lineno
                     value.targets[0].col_offset = value.targets[0].elts[0].col_offset
                     value.value.lineno = value.value.elts[0].lineno

--- a/meta/decompiler/simple_instructions.py
+++ b/meta/decompiler/simple_instructions.py
@@ -248,7 +248,6 @@ class SimpleInstructions(object):
                     value.targets[0].col_offset = value.targets[0].elts[0].col_offset
                     value.value.lineno = value.value.elts[0].lineno
                     value.value.col_offset = value.value.elts[0].col_offset
-
                 value.targets[0].elts.append(assname)
                 value.value.elts.append(_)
 

--- a/meta/decompiler/simple_instructions.py
+++ b/meta/decompiler/simple_instructions.py
@@ -238,7 +238,15 @@ class SimpleInstructions(object):
         elif isinstance(value, _ast.Assign):
             _ = self.pop_ast_item()
             assname = _ast.Name(instr.arg, _ast.Store(), lineno=instr.lineno, col_offset=0)
-            value.targets.append(assname)
+            if _ is value.value or isinstance(_, _ast.Assign):
+                value.targets.append(assname)
+            else:
+                if not isinstance(value.targets, _ast.Tuple):
+                    value.targets = [_ast.Tuple(value.targets, _ast.Store())]
+                    value.value = _ast.Tuple([value.value], _ast.Store())
+                value.targets[0].elts.append(assname)
+                value.value.elts.append(_)
+
             self.push_ast_item(value)
         else:
 

--- a/meta/decompiler/simple_instructions.py
+++ b/meta/decompiler/simple_instructions.py
@@ -244,6 +244,11 @@ class SimpleInstructions(object):
                 if not isinstance(value.targets, _ast.Tuple):
                     value.targets = [_ast.Tuple(value.targets, _ast.Store())]
                     value.value = _ast.Tuple([value.value], _ast.Store())
+                    value.targets[0].lineno = value.targets[0].elts[0].lineno
+                    value.targets[0].col_offset = value.targets[0].elts[0].col_offset
+                    value.value.lineno = value.value.elts[0].lineno
+                    value.value.col_offset = value.value.elts[0].col_offset
+
                 value.targets[0].elts.append(assname)
                 value.value.elts.append(_)
 

--- a/meta/decompiler/tests/test_decompiler.py
+++ b/meta/decompiler/tests/test_decompiler.py
@@ -537,6 +537,21 @@ else:
 '''
         self.statement(src)
         
+    def test_issue_027(self):
+        stmnt1 = '''
+def foo():
+    a, b = b, a
+    return None
+'''
+        self.statement(stmnt1)
+
+        stmnt2 = '''
+def foo():
+    a, b = 1, z
+    return None
+'''
+        self.statement(stmnt2)
+
         
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.test_assign']


### PR DESCRIPTION
Fixes issue #27 .

Old behavior incorrectly created multi-target assignment (`Assign(targets=[x, y], value=1)`) rather than unpacked assignment (`Assign(targets=[Tuple(x, y)], value=Tuple(1, 2))`) when the right-hand-side was not a constant inside a function.

   * not a constant: because Python bytecode loads a constant expression as a whole, rather than playing with registers, as it must for a right-hand-side involving symbols
   * inside a function: presumably different (correct) decompiling code handles the not-in-a-function case...

Includes a unit test called `test_issue027`.
