### PR TITLE
Fix issue caused by ast.Module signature change in python 3.8.

### DIFF
--- a/meta/decompiler/__init__.py
+++ b/meta/decompiler/__init__.py
@@ -50,7 +50,10 @@ def compile_func(ast_node, filename, globals, **defaults):
     '''
 
     funcion_name = ast_node.name
-    module = _ast.Module(body=[ast_node])
+    if sys.version_info >= (3, 8):
+        module = _ast.Module(body=[ast_node], type_ignores=[])
+    else:
+        module = _ast.Module([ast_node])
 
     ctx = {'%s_default' % key : arg for key, arg in defaults.items()}
 

--- a/meta/decompiler/__init__.py
+++ b/meta/decompiler/__init__.py
@@ -53,7 +53,7 @@ def compile_func(ast_node, filename, globals, **defaults):
     if sys.version_info >= (3, 8):
         module = _ast.Module(body=[ast_node], type_ignores=[])
     else:
-        module = _ast.Module([ast_node])
+        module = _ast.Module(body=[ast_node])
 
     ctx = {'%s_default' % key : arg for key, arg in defaults.items()}
 


### PR DESCRIPTION
Fix issue caused by ast.Module changing signature in 3.8 causing a TypeError.

Fix suggested from:
https://github.com/beetbox/beets/issues/3201#issuecomment-478341869