### PR TITLE
Update homepage URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email='srossross@enthought.com',
     maintainer='Sean Ross-Ross',
     maintainer_email='enthought-dev@enthought.com',
-    url='http://srossross.github.com/Meta',
+    url='http://srossross.github.io/Meta',
 
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
The original URL is 404:

> If you're the owner of this site, please update your links to use srossross.github.io instead. Subdomains of github.com are deprecated for GitHub Pages. They will not redirect to github.io after April 15, 2021.